### PR TITLE
Add beach sand

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+-r ./app/beach_sand.rb

--- a/app/beach_sand.rb
+++ b/app/beach_sand.rb
@@ -1,0 +1,7 @@
+module BeachSand; end
+
+files = Dir.glob(File.join(__dir__, "**", "*.rb"))
+
+files.each do |file|
+  require file unless file == __FILE__
+end

--- a/app/beach_sand/message_deleter.rb
+++ b/app/beach_sand/message_deleter.rb
@@ -1,0 +1,81 @@
+require "json"
+
+module BeachSand
+  class MessageDeleter
+    DeleteReason = "The tides of time silence the qualms of life".freeze
+    MaxNumberOfMessages = 100
+
+    class NoMessagesError < StandardError; end
+
+    # @param [Number] message_id
+    # @param [Number] channel_id
+    # @param [String] api_token
+    def initialize(message_id:, channel_id:, api_token:)
+      @message_id = message_id
+      @channel_id = channel_id
+      @api_token = api_token
+    end
+
+    def execute
+      raise ArgumentError, "Need a message id" unless @message_id
+
+      messages = fetch_messages
+
+      if messages.any?
+        raise NoMessagesError, "Could not find any messages in channel: #{@channel_id} after message id: #{@message_id}"
+      end
+
+      delete_messages(messages)
+    end
+
+    private
+
+    def fetch_messages
+      all_messages = []
+
+      max_id = @message_id
+
+      loop do
+        # only of before/after/around can be used at a given time
+        #
+        # @see https://discord.com/developers/docs/resources/channel#get-channel-messages
+        api_response = Discordrb::API::Channel.messages(
+          @api_token,
+          @channel_id,
+          MaxNumberOfMessages, # amount of messages (max 100)
+          nil, # messages before this id
+          max_id, # messages after this id
+          nil, # messages around this id
+        )
+
+        break unless api_response.code == 200
+
+        messages = BeachSand::Structs::DiscordMessage
+          .from_api_response(JSON.parse(api_response))
+          .select(&:deletable?)
+
+        break unless messages.any?
+
+        all_messages += messages
+
+        max_id = messages.map(&:id).max
+      end
+
+      all_messages
+    end
+
+    def delete_messages(messages)
+      messages.each_slice(MaxNumberOfMessages) do |message_slice|
+        LOGGER.info "Deleting messages: #{message_slice.size}"
+        LOGGER.info "Message ID: #{message_slice.map(&:id)}"
+
+        Discordrb::API::Channel.bulk_delete_messages(
+          @api_token,
+          @channel_id,
+          message_slice.map(&:id),
+          DeleteReason,
+        )
+      end
+    end
+  end
+end

--- a/app/beach_sand/structs/discord_message.rb
+++ b/app/beach_sand/structs/discord_message.rb
@@ -21,12 +21,6 @@ module BeachSand
       def deletable?
         timestamp.to_time.to_i > (Time.now.to_i - TwoWeeksAgo)
       end
-
-      def between_time?(start_time, end_time)
-        message_time = timestamp.to_time.to_i 
-
-        message_time >= start_time.to_i && message_time <= end_time.to_i
-      end
     end
   end
 end

--- a/app/beach_sand/structs/discord_message.rb
+++ b/app/beach_sand/structs/discord_message.rb
@@ -1,0 +1,28 @@
+module BeachSand
+  module Structs
+    DiscordMessage = Struct.new(:id, :author_id, :timestamp, keyword_init: true) do
+      # 60 seconds, for 60 minutes, 24 times a day, 7 days in a week, for two weeks
+      TwoWeeksAgo = 60 * 60 * 24 * 7 * 2
+
+      def self.from_api_response(response)
+        response.map do |msg|
+          new(
+            id: msg["id"],
+            author_id: msg.dig("author", "id"),
+            timestamp: DateTime.parse(msg["timestamp"]),
+          )
+        end
+      end
+
+      def deletable?
+        timestamp.to_time.to_i > (Time.now.to_i - TwoWeeksAgo)
+      end
+
+      def between_time?(start_time, end_time)
+        message_time = timestamp.to_time.to_i 
+
+        message_time >= start_time && message_time <= end_time
+      end
+    end
+  end
+end

--- a/app/beach_sand/structs/discord_message.rb
+++ b/app/beach_sand/structs/discord_message.rb
@@ -1,9 +1,13 @@
+require "date"
+require "time"
+
 module BeachSand
   module Structs
-    DiscordMessage = Struct.new(:id, :author_id, :timestamp, keyword_init: true) do
-      # 60 seconds, for 60 minutes, 24 times a day, 7 days in a week, for two weeks
-      TwoWeeksAgo = 60 * 60 * 24 * 7 * 2
+    # 60 seconds, for 60 minutes, 24 times a day, 7 days in a week, for two weeks
+    TwoWeeksAgo = 60 * 60 * 24 * 7 * 2
 
+    DiscordMessage = Struct.new(:id, :author_id, :timestamp, keyword_init: true) do
+      # @return [Array[DiscordMessage]]
       def self.from_api_response(response)
         response.map do |msg|
           new(
@@ -21,7 +25,7 @@ module BeachSand
       def between_time?(start_time, end_time)
         message_time = timestamp.to_time.to_i 
 
-        message_time >= start_time && message_time <= end_time
+        message_time >= start_time.to_i && message_time <= end_time.to_i
       end
     end
   end

--- a/bot.rb
+++ b/bot.rb
@@ -4,6 +4,7 @@ require_relative "./app/constants"
 require_relative "./app/discord/command"
 require_relative "./app/vaccine_spotter/api"
 require_relative "./app/vaccine_spotter/result"
+require_relative "./app/beach_sand"
 
 LOGGER = Logger.new($stdout)
 LOGGER.level = Logger::INFO

--- a/bot.rb
+++ b/bot.rb
@@ -18,7 +18,7 @@ VACCINE_TYPES.each do |type|
   command_config = {
     help_available: true,
     description: "Find #{type} vaccines",
-    usage: <<~USAGE.strip,
+    usage: <<~USAGE.strip
       !#{type} <STATE> [<CITY> (optional)] <zipcode1> <zipcode2> ... <zipcodeN>
 
       Examples:
@@ -43,6 +43,30 @@ VACCINE_TYPES.each do |type|
     VaccineSpotter::Result.display(locations).tap do |msg|
       LOGGER.info msg
     end
+  end
+end
+
+bot.command(
+  :beach,
+  help_available: true,
+  description: "Primes the sands for temporary messaging.",
+  usage: "React to the first message the bot posted with :ocean: to cause a deluge",
+) do |event|
+  msg = event.response "The waves subside. For a brief moment, you can write in sand before then next tide. When you are done, react to the bot message with :ocean:."
+  done_emoji = "\u{1f30a}"
+
+  msg.react(done_emoji)
+
+  bot.add_await!(Discordrb::Events::ReactionAddEvent, emoji: done_emoji, timeout: 600, message: msg) do |reaction_event|
+    deleter = BeachSand::MessageDeleter.new(message_id: msg.idd, channel_id: msg.channel.id, api_token: bot.token)
+
+    begin
+      deleter.execute
+    rescue NoMessagesError, ArgumentError => e
+      LOGGER.error(e)
+    end
+
+    reaction_event.respond "The tides roll in, and the sand begins to smooth out."
   end
 end
 

--- a/spec/app/beach_sand/message_deleter_spec.rb
+++ b/spec/app/beach_sand/message_deleter_spec.rb
@@ -1,0 +1,159 @@
+require "spec_helper"
+require "discordrb"
+
+describe BeachSand::MessageDeleter do
+  describe "#execute" do
+    before do
+      allow(Discordrb::API::Channel).to receive(:messages)
+      allow(Discordrb::API::Channel).to receive(:bulk_delete_messages)
+    end
+
+    context "when a message id is not provided" do
+      it "does not run" do
+        instance = BeachSand::MessageDeleter.new(message_id: nil, channel_id: 1, api_token: "test")
+
+        expect { instance.execute }.to raise_error(ArgumentError, "Need a message id")
+      end
+    end
+
+    context "when no messages are returned from discord" do
+      it "raises an error" do
+        mock_channel_id = 1
+        mock_token = "test"
+        mock_message_id = 1
+
+        mock_api_response = double(code: 204)
+
+        allow(Discordrb::API::Channel).to receive(:messages).with(
+          mock_token,
+          mock_channel_id,
+          BeachSand::MessageDeleter::MaxNumberOfMessages,
+          nil,
+          mock_message_id,
+          nil
+        ).and_return(mock_api_response)
+
+        instance = BeachSand::MessageDeleter.new(
+          message_id: mock_message_id,
+          channel_id: mock_channel_id,
+          api_token: mock_token,
+        )
+
+        expect { instance.execute }.to raise_error(BeachSand::MessageDeleter::NoMessagesError)
+      end
+    end
+
+    context "when messages are returned from discord" do
+      it "deletes them" do
+        mock_channel_id = 1
+        mock_token = "test"
+        mock_message_id = 1
+        mock_response = [
+          {
+            id: 1,
+            author: { id: 1 },
+            timestamp: Time.now.to_s,
+          }
+        ]
+
+
+        mock_api_response = double(code: 200, to_s: JSON.dump(mock_response))
+
+        allow(Discordrb::API::Channel).to receive(:messages).with(
+          mock_token,
+          mock_channel_id,
+          BeachSand::MessageDeleter::MaxNumberOfMessages,
+          nil,
+          mock_message_id,
+          nil
+        ).and_return(mock_api_response)
+
+        instance = BeachSand::MessageDeleter.new(
+          message_id: mock_message_id,
+          channel_id: mock_channel_id,
+          api_token: mock_token,
+        )
+
+        instance.execute
+
+        expect(Discordrb::API::Channel).to have_received(:bulk_delete_messages).exactly(1).time
+
+        expect(Discordrb::API::Channel).to have_received(:bulk_delete_messages).with(
+          mock_token,
+          mock_channel_id,
+          [1],
+          BeachSand::MessageDeleter::DeleteReason,
+        )
+      end
+
+      it "paginates results and deletes them in batches" do
+        mock_channel_id = 1
+        mock_token = "test"
+        mock_message_id = 1
+        mock_response = 120.times.map do |i|
+          {
+            id: i + 1,
+            author: { id: i + 1 },
+            timestamp: Time.now.to_s,
+          }
+        end
+
+
+        mock_api_response = double(code: 200, to_s: JSON.dump(mock_response.first(100)))
+        mock_api_response2 = double(code: 200, to_s: JSON.dump(mock_response.last(20)))
+        mock_api_response3 = double(code: 200, to_s: JSON.dump([]))
+
+        allow(Discordrb::API::Channel).to receive(:messages).with(
+          mock_token,
+          mock_channel_id,
+          BeachSand::MessageDeleter::MaxNumberOfMessages,
+          nil,
+          mock_message_id,
+          nil
+        ).and_return(mock_api_response)
+
+        allow(Discordrb::API::Channel).to receive(:messages).with(
+          mock_token,
+          mock_channel_id,
+          BeachSand::MessageDeleter::MaxNumberOfMessages,
+          nil,
+          100, # the next max id
+          nil
+        ).and_return(mock_api_response2)
+
+        allow(Discordrb::API::Channel).to receive(:messages).with(
+          mock_token,
+          mock_channel_id,
+          BeachSand::MessageDeleter::MaxNumberOfMessages,
+          nil,
+          120, # the next max id
+          nil
+        ).and_return(mock_api_response3)
+
+        instance = BeachSand::MessageDeleter.new(
+          message_id: mock_message_id,
+          channel_id: mock_channel_id,
+          api_token: mock_token,
+        )
+
+        instance.execute
+
+        expect(Discordrb::API::Channel).to have_received(:bulk_delete_messages).exactly(2).times
+
+        expect(Discordrb::API::Channel).to have_received(:bulk_delete_messages).with(
+          mock_token,
+          mock_channel_id,
+          (1..100).map(&:to_i),
+          BeachSand::MessageDeleter::DeleteReason,
+        )
+
+        expect(Discordrb::API::Channel).to have_received(:bulk_delete_messages).with(
+          mock_token,
+          mock_channel_id,
+          (101..120).map(&:to_i),
+          BeachSand::MessageDeleter::DeleteReason,
+        )
+      end
+    end
+  end
+end

--- a/spec/app/beach_sand/structs/discord_message_spec.rb
+++ b/spec/app/beach_sand/structs/discord_message_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+
+describe BeachSand::Structs::DiscordMessage do
+  describe ".from_api_response" do
+    let(:response) {
+      [
+        {
+          "id" => "1",
+          "author" => { "id" => "1" },
+          "timestamp" => "2021-01-01",
+        },
+        {
+          "id" => "2",
+          "author" => { "id" => "1" },
+          "timestamp" => "2021-01-01",
+        }
+      ]
+    }
+
+    it "returns an array of messages" do
+      results = BeachSand::Structs::DiscordMessage.from_api_response(response)
+      expect(results).to all(be_a(BeachSand::Structs::DiscordMessage))
+
+      expect(results.size).to eq(2)
+
+      expect(results.first).to have_attributes(id: "1", author_id: "1")
+      expect(results.last).to have_attributes(id: "2", author_id: "1")
+    end
+  end
+
+  describe "#deletable?" do
+    context "when the message is older than a few weeks ago" do
+      it "is false" do
+        instance = BeachSand::Structs::DiscordMessage.new(id: 1, author_id: 1, timestamp: Time.at(Time.now - (BeachSand::Structs::TwoWeeksAgo + 10)))
+
+        expect(instance.deletable?).to be_falsey
+      end
+    end
+
+    context "when the message is within the last two weeks" do
+      it "is true" do
+        instance = BeachSand::Structs::DiscordMessage.new(id: 1, author_id: 1, timestamp: Time.now)
+
+        expect(instance.deletable?).to be_truthy
+      end
+    end
+  end
+
+  describe "#between_time?" do
+    let(:instance) { BeachSand::Structs::DiscordMessage.new(id: 1, author_id: 1, timestamp: Time.now) }
+    let(:now) { Time.now }
+    let(:tomorrow) { Time.at(Time.now.to_i + (60 * 60 * 24)) }
+    let(:yesterday) { Time.at(Time.now.to_i - (60 * 60 * 24)) }
+
+    context "when the start time is after the end time" do
+      it "is false" do
+        expect(instance.between_time?(tomorrow, yesterday)).to be_falsey
+      end
+    end
+
+    context "when the start time is before the end time" do
+      it "is true if the timestamp is between both times" do
+        expect(instance.between_time?(yesterday, tomorrow)).to be_truthy
+      end
+
+      it "is false if the timestamp is not between both times" do
+        expect(instance.between_time?(tomorrow, Time.at(tomorrow.to_i + 60 * 60 * 24))).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/app/beach_sand/structs/discord_message_spec.rb
+++ b/spec/app/beach_sand/structs/discord_message_spec.rb
@@ -45,27 +45,4 @@ describe BeachSand::Structs::DiscordMessage do
       end
     end
   end
-
-  describe "#between_time?" do
-    let(:instance) { BeachSand::Structs::DiscordMessage.new(id: 1, author_id: 1, timestamp: Time.now) }
-    let(:now) { Time.now }
-    let(:tomorrow) { Time.at(Time.now.to_i + (60 * 60 * 24)) }
-    let(:yesterday) { Time.at(Time.now.to_i - (60 * 60 * 24)) }
-
-    context "when the start time is after the end time" do
-      it "is false" do
-        expect(instance.between_time?(tomorrow, yesterday)).to be_falsey
-      end
-    end
-
-    context "when the start time is before the end time" do
-      it "is true if the timestamp is between both times" do
-        expect(instance.between_time?(yesterday, tomorrow)).to be_truthy
-      end
-
-      it "is false if the timestamp is not between both times" do
-        expect(instance.between_time?(tomorrow, Time.at(tomorrow.to_i + 60 * 60 * 24))).to be_falsey
-      end
-    end
-  end
 end


### PR DESCRIPTION
This pull request adds a new bot command that will enable off-the-record functionality in Discord.

The idea being that you invoke a command, then an OTR session begins. It will continue until someone reacts with the 🌊 emoji, or it just deletes itself in the next 10 minutes.

Once this is merged in, we should change the name of this project to be a little bit more generic.