### PR TITLE
Add a session manager for beach

### DIFF
--- a/app/beach_sand/session_manager.rb
+++ b/app/beach_sand/session_manager.rb
@@ -1,0 +1,25 @@
+require "set"
+
+module BeachSand
+  class SessionManager
+    class << self
+      def acquire_lock(lock_name)
+        !!session_store.add?(lock_name)
+      end
+
+      def release_lock(lock_name)
+        !!session_store.delete?(lock_name)
+      end
+
+      def release_all!
+        !!session_store.clear
+      end
+
+      private
+
+      def session_store
+        @session_store ||= Set.new([])
+      end
+    end
+  end
+end

--- a/spec/app/beach_sand/session_manager_spec.rb
+++ b/spec/app/beach_sand/session_manager_spec.rb
@@ -1,0 +1,45 @@
+describe BeachSand::SessionManager do
+  before do
+    BeachSand::SessionManager.release_all!
+  end
+
+  describe ".acquire_lock" do
+    it "returns true if it adds a lock that doesn't exist" do
+      expect(BeachSand::SessionManager.acquire_lock("123")).to eq(true)
+    end
+
+    it "returns false if it adds a lock that already exists" do
+      expect(BeachSand::SessionManager.acquire_lock("123")).to eq(true)
+      expect(BeachSand::SessionManager.acquire_lock("123")).to eq(false)
+    end
+  end
+
+  describe ".release_lock" do
+    it "return false if the lock doesn't exist" do
+      expect(BeachSand::SessionManager.release_lock("123")).to eq(false)
+    end
+
+    it "return true if the lock exists and is removed" do
+      BeachSand::SessionManager.acquire_lock("123")
+      expect(BeachSand::SessionManager.release_lock("123")).to eq(true)
+      expect(BeachSand::SessionManager.release_lock("123")).to eq(false)
+    end
+  end
+
+  describe ".release_all!" do
+    it "deletes all locks" do
+      locks = %w(one two three four)
+
+      locks.each do |lock|
+        expect(BeachSand::SessionManager.acquire_lock(lock)).to eq(true)
+        expect(BeachSand::SessionManager.acquire_lock(lock)).to eq(false)
+      end
+
+      BeachSand::SessionManager.release_all!
+
+      locks.each do |lock|
+        expect(BeachSand::SessionManager.release_lock(lock)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a session manager that acts as an interface for managing a beach session. This will be useful as we will probably be migrating this over to a Redis-based session store for temporary locks.