### PR TITLE
Use a distributed lock store for keeping track of active sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "rspec"
-gem "pry"
 gem "discordrb", "~> 3.4"
+gem "pry"
+gem "redlock"
+gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,9 @@ GEM
     pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    redis (4.4.0)
+    redlock (1.2.1)
+      redis (>= 3.0.0, < 5.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -61,6 +64,7 @@ PLATFORMS
 DEPENDENCIES
   discordrb (~> 3.4)
   pry
+  redlock
   rspec
 
 BUNDLED WITH

--- a/app/beach_sand/session_manager.rb
+++ b/app/beach_sand/session_manager.rb
@@ -44,7 +44,7 @@ module BeachSand
       end
 
       def redlock_client
-        @redlock_client ||= Redlock::Client.new([ ENV["REDIS_TLS_URL"] ]) if redlock_enabled?
+        @redlock_client ||= Redlock::Client.new([ ENV["REDIS_URL"] ]) if redlock_enabled?
       end
     end
   end

--- a/app/beach_sand/session_manager.rb
+++ b/app/beach_sand/session_manager.rb
@@ -1,14 +1,32 @@
 require "set"
+require "redlock"
 
 module BeachSand
   class SessionManager
+    class BadTimeout < StandardError; end
+
+    MaxTimeoutAllowed = 1_000 * 60 * 60 # 1 hour, in milliseconds
+    MinTimeoutAllowed = 1_000 * 60 # 1 minute, in milliseconds
+
     class << self
-      def acquire_lock(lock_name)
-        !!session_store.add?(lock_name)
+      def acquire_lock(lock_name, timeout: nil)
+        if redlock_enabled?
+          raise BadTimeout, "Timeout must be provided (in milliseconds)" if timeout.nil?
+          raise BadTimeout, "Timeout must be at least #{MinTimeoutAllowed / 1_000} seconds" if timeout < MinTimeoutAllowed
+          raise BadTimeout, "Timeout must be at most #{MaxTimeoutAllowed / 1_000} seconds" if timeout > MaxTimeoutAllowed
+
+          redlock_client.lock(lock_name, timeout)
+        else
+          !!session_store.add?(lock_name)
+        end
       end
 
       def release_lock(lock_name)
-        !!session_store.delete?(lock_name)
+        if redlock_enabled?
+          redlock_client.unlock(lock_name)
+        else
+          !!session_store.delete?(lock_name)
+        end
       end
 
       def release_all!
@@ -19,6 +37,14 @@ module BeachSand
 
       def session_store
         @session_store ||= Set.new([])
+      end
+
+      def redlock_enabled?
+        @redlock_enabled ||= !ENV.fetch("REDIS_URL", "").empty?
+      end
+
+      def redlock_client
+        @redlock_client ||= Redlock::Client.new([ ENV["REDIS_TLS_URL"] ]) if redlock_enabled?
       end
     end
   end


### PR DESCRIPTION
This pull request introduces `Redlock`, a gem for distributed locks backed by Redis.

This is useful because it allows us to:

- auto-expire locks
- not get impacted by a deploy