### PR TITLE
Minor Vaccine API cleanup

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -27,10 +27,10 @@ Vaccines::Types.each do |type|
   vaccine_guid = Vaccines::TypeToGuid[type]
 
   bot.command(type.to_sym, command_config) do |_event, postal_code|
-    locations = Vaccines::Api.find(vaccine_guid: vaccine_guid, postal_code: postal_code)
+    providers = Vaccines::Api.new(vaccine_guid).find_in(postal_code: postal_code)
 
-    if locations.any?
-      Vaccines::Result.display(locations.sort_by(&:distance).first(7))
+    if providers.any?
+      Vaccines::Result.display(providers.sort_by(&:distance).first(7))
     else
       "Did not find any appointments for #{postal_code}"
     end

--- a/spec/app/vaccines/api_spec.rb
+++ b/spec/app/vaccines/api_spec.rb
@@ -1,4 +1,5 @@
 describe Vaccines::Api do
+  let(:instance) { described_class.new("mock_guid") }
   let(:mock_http) { Net::HTTP.new(url.host) }
 
   before do
@@ -6,7 +7,7 @@ describe Vaccines::Api do
     allow(Net::HTTP).to receive(:start).and_yield(mock_http)
   end
 
-  describe ".find" do
+  describe "#find_in" do
     let(:url) { URI("#{described_class.send(:api_url)}/provider-locations/search") }
 
     before do
@@ -25,8 +26,7 @@ describe Vaccines::Api do
       end
 
       it "returns a list of providers" do
-        expect(described_class.find(vaccine_guid: "mock_guid", postal_code: "60601"))
-          .to all(be_a(Vaccines::Structs::Provider))
+        expect(instance.find_in(postal_code: "60601")).to all(be_a(Vaccines::Structs::Provider))
       end
     end
 
@@ -36,14 +36,14 @@ describe Vaccines::Api do
       end
 
       it "returns an empty list" do
-        expect(described_class.find(vaccine_guid: "mock_guid", postal_code: "60601")).to be_empty
+        expect(instance.find_in(postal_code: "60601")).to be_empty
       end
     end
 
     context "using an invalid radius" do
       it "raises an exception" do
         expect do
-          described_class.find(vaccine_guid: "mock_orange", postal_code: "60601", radius: 3)
+          instance.find_in(postal_code: "60601", radius: 3)
         end.to raise_error(
           a_string_including(
             "Invalid radius `3`.",

--- a/spec/app/vaccines/api_spec.rb
+++ b/spec/app/vaccines/api_spec.rb
@@ -8,7 +8,7 @@ describe Vaccines::Api do
   end
 
   describe "#find_in" do
-    let(:url) { URI("#{described_class.send(:api_url)}/provider-locations/search") }
+    let(:url) { URI("#{instance.send(:api_url)}/provider-locations/search") }
 
     before do
       allow(Services::Mapbox::Api).to receive(:geocode_postal_code).and_return([40.0, -81.0])


### PR DESCRIPTION
This pull request updates how we use the `Vaccine::API` class. It stores the vaccine guid as state, and removes the need to look up all vaccine types.